### PR TITLE
Added initial rotate around arbitrary axis matrix functions

### DIFF
--- a/UseNGL.pri
+++ b/UseNGL.pri
@@ -2,7 +2,6 @@
 #in the default $(HOME)/NGL/  directory if this can't be found the environment variable $NGLDIR will be searched for and this will be used.
 CONFIG+=c++11
 
-
 # as I want to support 4.8 and 5 this will set a flag for some of the mac stuff
 # mainly in the types.h file for the setMacVisual which is native in Qt5
 isEqual(QT_MAJOR_VERSION, 5) {
@@ -23,7 +22,7 @@ message($${NGLBASE})
 # use this to suppress some warning from boost
 unix*:QMAKE_CXXFLAGS_WARN_ON += "-Wno-unused-parameter"
 # basic compiler flags (not all appropriate for all platforms)
-QMAKE_CXXFLAGS+= -msse -msse2 -msse3
+QMAKE_CXXFLAGS+= -msse -msse2 -msse3 -fopenmp
 macx:QMAKE_CXXFLAGS+= -arch x86_64
 macx:INCLUDEPATH+=/usr/local/include/
 linux-g++:QMAKE_CXXFLAGS +=  -march=native
@@ -70,5 +69,6 @@ ios {
 
 }
 
+QMAKE_RPATHDIR+=/Users/v0q/clang-omp/build/lib
 QMAKE_RPATHDIR+=$${NGLBASE}/lib
 

--- a/include/ngl/Mat4.h
+++ b/include/ngl/Mat4.h
@@ -161,6 +161,27 @@ public:
   const Mat4& transpose() noexcept;
 
   //----------------------------------------------------------------------------------------------------------------------
+  /// @brief Rotate around an arbitrary axis
+  /// @param[in] _i component of the axis
+  /// @param[in] _j component of the axis
+  /// @param[in] _k component of the axis
+  /// @param[in] _deg the value to be rotated by in degrees
+  //----------------------------------------------------------------------------------------------------------------------
+  void rotate(const Real &_i, const Real &_j, const Real &_k, const Real &_deg) noexcept;
+  //----------------------------------------------------------------------------------------------------------------------
+  /// @brief Rotate around an arbitrary axis
+  /// @param[in] _axis Axis that the rotation happens around
+  /// @param[in] _deg the value to be rotated by in degrees
+  //----------------------------------------------------------------------------------------------------------------------
+  void rotate(const ngl::Vec3 &_axis, const Real &_deg) noexcept;
+  //----------------------------------------------------------------------------------------------------------------------
+  /// @brief Rotate around an arbitrary axis
+  /// @param[in] _axis Axis that the rotation happens around
+  /// @param[in] _sp Starting point of the rotation axis
+  /// @param[in] _deg the value to be rotated by in degrees
+  //----------------------------------------------------------------------------------------------------------------------
+  void rotate(const ngl::Vec3 &_axis, const Vec3 &_sp, const Real &_deg) noexcept;
+  //----------------------------------------------------------------------------------------------------------------------
   /// @brief set this matrix to a rotation matrix in the X axis for value _deg
   /// note the matrix should be set to identity before doing this
   /// @param[in] _deg the value to be rotated by in degrees

--- a/src/Mat4.cpp
+++ b/src/Mat4.cpp
@@ -389,7 +389,52 @@ const Mat4& Mat4::transpose() noexcept
 	return *this;
 }
 
+//----------------------------------------------------------------------------------------------------------------------
+void Mat4::rotate(const Real &_i, const Real &_j, const Real &_k, const Real &_deg) noexcept
+{
+  Vec3 tmp(_i, _j, _k);
+  rotate(tmp, Vec3(0.f, 0.f, 0.f), _deg);
+}
 
+//----------------------------------------------------------------------------------------------------------------------
+void Mat4::rotate(const Vec3 &_axis, const Real &_deg ) noexcept
+{
+  rotate(_axis, Vec3(0.f, 0.f, 0.f), _deg);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+void Mat4::rotate(const Vec3 &_axis, const Vec3 &_sp, const Real &_deg ) noexcept
+{
+  Vec3 tmp = _axis;
+  tmp.normalize();
+
+  Real beta = radians(_deg);
+  Real sr = sin(beta);
+  Real cr = cos(beta);
+
+  m_00  =  tmp.m_x*tmp.m_x + (tmp.m_y*tmp.m_y + tmp.m_z*tmp.m_z) * cr;
+  m_01  =  tmp.m_x*tmp.m_y * (1 - cr) - tmp.m_z*sr;
+  m_02  =  tmp.m_x*tmp.m_z * (1 - cr) + tmp.m_y*sr;
+  m_03  =  (_sp.m_x * (tmp.m_y*tmp.m_y + tmp.m_z*tmp.m_z) - tmp.m_x * (_sp.m_y*tmp.m_y + _sp.m_z*tmp.m_z)) * (1 - cr) + (_sp.m_y*tmp.m_z - _sp.m_z*tmp.m_y) * sr;
+
+  //  row 1
+  m_10  =  tmp.m_x*tmp.m_y * (1 - cr) + tmp.m_z*sr;
+  m_11  =  tmp.m_y*tmp.m_y + (tmp.m_x*tmp.m_x + tmp.m_z*tmp.m_z) * cr;
+  m_12  =  tmp.m_y*tmp.m_z * (1 - cr) - tmp.m_x*sr;
+  m_13  =  (_sp.m_y * (tmp.m_x*tmp.m_x + tmp.m_z*tmp.m_z) - tmp.m_y * (_sp.m_x*tmp.m_x + _sp.m_z*tmp.m_z)) * (1 - cr) + (_sp.m_z*tmp.m_x - _sp.m_x*tmp.m_z) * sr;
+
+  //  row 2
+  m_20  =  tmp.m_x*tmp.m_z * (1 - cr) - tmp.m_y*sr;
+  m_21  =  tmp.m_y*tmp.m_z * (1 - cr) + tmp.m_x*sr;
+  m_22  =  tmp.m_z*tmp.m_z + (tmp.m_x*tmp.m_x + tmp.m_y*tmp.m_y) * cr;
+  m_23  =  (_sp.m_z * (tmp.m_x*tmp.m_x + tmp.m_y*tmp.m_y) - tmp.m_z*(_sp.m_x*tmp.m_x + _sp.m_y*tmp.m_y)) * (1 - cr) + (_sp.m_x*tmp.m_y - _sp.m_y*tmp.m_x) * sr;
+
+  //  row 3
+  m_30  =  0;
+  m_31  =  0;
+  m_32  =  0;
+  m_33  =  1;
+}
 
 //----------------------------------------------------------------------------------------------------------------------
 void Mat4::rotateX( const Real _deg) noexcept

--- a/src/Mat4.cpp
+++ b/src/Mat4.cpp
@@ -413,27 +413,28 @@ void Mat4::rotate(const Vec3 &_axis, const Vec3 &_sp, const Real &_deg ) noexcep
   Real cr = cos(beta);
 
   m_00  =  tmp.m_x*tmp.m_x + (tmp.m_y*tmp.m_y + tmp.m_z*tmp.m_z) * cr;
-  m_01  =  tmp.m_x*tmp.m_y * (1 - cr) - tmp.m_z*sr;
-  m_02  =  tmp.m_x*tmp.m_z * (1 - cr) + tmp.m_y*sr;
-  m_03  =  (_sp.m_x * (tmp.m_y*tmp.m_y + tmp.m_z*tmp.m_z) - tmp.m_x * (_sp.m_y*tmp.m_y + _sp.m_z*tmp.m_z)) * (1 - cr) + (_sp.m_y*tmp.m_z - _sp.m_z*tmp.m_y) * sr;
+  m_10  =  tmp.m_x*tmp.m_y * (1 - cr) - tmp.m_z*sr;
+  m_20  =  tmp.m_x*tmp.m_z * (1 - cr) + tmp.m_y*sr;
+  m_30  =  (_sp.m_x * (tmp.m_y*tmp.m_y + tmp.m_z*tmp.m_z) - tmp.m_x * (_sp.m_y*tmp.m_y + _sp.m_z*tmp.m_z)) * (1 - cr) + (_sp.m_y*tmp.m_z - _sp.m_z*tmp.m_y) * sr;
 
   //  row 1
-  m_10  =  tmp.m_x*tmp.m_y * (1 - cr) + tmp.m_z*sr;
+  m_01  =  tmp.m_x*tmp.m_y * (1 - cr) + tmp.m_z*sr;
   m_11  =  tmp.m_y*tmp.m_y + (tmp.m_x*tmp.m_x + tmp.m_z*tmp.m_z) * cr;
-  m_12  =  tmp.m_y*tmp.m_z * (1 - cr) - tmp.m_x*sr;
-  m_13  =  (_sp.m_y * (tmp.m_x*tmp.m_x + tmp.m_z*tmp.m_z) - tmp.m_y * (_sp.m_x*tmp.m_x + _sp.m_z*tmp.m_z)) * (1 - cr) + (_sp.m_z*tmp.m_x - _sp.m_x*tmp.m_z) * sr;
+  m_21  =  tmp.m_y*tmp.m_z * (1 - cr) - tmp.m_x*sr;
+  m_31  =  (_sp.m_y * (tmp.m_x*tmp.m_x + tmp.m_z*tmp.m_z) - tmp.m_y * (_sp.m_x*tmp.m_x + _sp.m_z*tmp.m_z)) * (1 - cr) + (_sp.m_z*tmp.m_x - _sp.m_x*tmp.m_z) * sr;
 
   //  row 2
-  m_20  =  tmp.m_x*tmp.m_z * (1 - cr) - tmp.m_y*sr;
-  m_21  =  tmp.m_y*tmp.m_z * (1 - cr) + tmp.m_x*sr;
+  m_02  =  tmp.m_x*tmp.m_z * (1 - cr) - tmp.m_y*sr;
+  m_12  =  tmp.m_y*tmp.m_z * (1 - cr) + tmp.m_x*sr;
   m_22  =  tmp.m_z*tmp.m_z + (tmp.m_x*tmp.m_x + tmp.m_y*tmp.m_y) * cr;
-  m_23  =  (_sp.m_z * (tmp.m_x*tmp.m_x + tmp.m_y*tmp.m_y) - tmp.m_z*(_sp.m_x*tmp.m_x + _sp.m_y*tmp.m_y)) * (1 - cr) + (_sp.m_x*tmp.m_y - _sp.m_y*tmp.m_x) * sr;
+  m_32  =  (_sp.m_z * (tmp.m_x*tmp.m_x + tmp.m_y*tmp.m_y) - tmp.m_z * (_sp.m_x*tmp.m_x + _sp.m_y*tmp.m_y)) * (1 - cr) + (_sp.m_x*tmp.m_y - _sp.m_y*tmp.m_x) * sr;
 
   //  row 3
-  m_30  =  0;
-  m_31  =  0;
-  m_32  =  0;
+  m_03  =  0;
+  m_13  =  0;
+  m_23  =  0;
   m_33  =  1;
+//  this->transpose();
 }
 
 //----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
The Mat4 (only added to Mat4 for now) class was missing the functions to rotate about an arbitrary axis. Created these functions. Atm calling these functions will overwrite the existing matrix so it should be used as a separate matrix.
