### PR TITLE
update fmt headers to those included in fmt 4.0.0 release

### DIFF
--- a/include/ngl/fmt/CMakeLists.txt
+++ b/include/ngl/fmt/CMakeLists.txt
@@ -1,0 +1,90 @@
+# Define the fmt library, its includes and the needed defines.
+# *.cc are added to FMT_HEADERS for the header-only configuration.
+set(FMT_HEADERS container.h format.h format.cc ostream.h ostream.cc printf.h
+                printf.cc string.h time.h)
+if (HAVE_OPEN)
+  set(FMT_HEADERS ${FMT_HEADERS} posix.h)
+  set(FMT_SOURCES ${FMT_SOURCES} posix.cc)
+endif ()
+
+add_library(fmt ${FMT_SOURCES} ${FMT_HEADERS} ../README.rst ../ChangeLog.rst)
+add_library(fmt::fmt ALIAS fmt)
+
+# Starting with cmake 3.1 the CXX_STANDARD property can be used instead.
+# Note: Don't make -std=c++11 public or interface, since it breaks projects
+# that use C++14.
+target_compile_options(fmt PRIVATE ${CPP11_FLAG})
+if (FMT_PEDANTIC)
+  target_compile_options(fmt PRIVATE ${PEDANTIC_COMPILE_FLAGS})
+endif ()
+
+target_include_directories(fmt PUBLIC
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include>)
+
+set_target_properties(fmt PROPERTIES
+  VERSION ${FMT_VERSION} SOVERSION ${CPACK_PACKAGE_VERSION_MAJOR})
+
+if (BUILD_SHARED_LIBS)
+  if (UNIX AND NOT APPLE)
+    # Fix rpmlint warning:
+    # unused-direct-shlib-dependency /usr/lib/libformat.so.1.1.0 /lib/libm.so.6.
+    target_link_libraries(fmt -Wl,--as-needed)
+  endif ()
+  target_compile_definitions(fmt PRIVATE FMT_EXPORT INTERFACE FMT_SHARED)
+endif ()
+
+#------------------------------------------------------------------------------
+# additionally define a header only library when cmake is new enough
+if (CMAKE_VERSION VERSION_GREATER 3.1.0 OR CMAKE_VERSION VERSION_EQUAL 3.1.0)
+  add_library(fmt-header-only INTERFACE)
+  add_library(fmt::fmt-header-only ALIAS fmt-header-only)
+
+  target_compile_definitions(fmt-header-only INTERFACE FMT_HEADER_ONLY=1)
+
+  target_include_directories(fmt-header-only INTERFACE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>)
+endif ()
+
+# Install targets.
+if (FMT_INSTALL)
+  include(CMakePackageConfigHelpers)
+  set(FMT_CMAKE_DIR lib/cmake/fmt CACHE STRING
+    "Installation directory for cmake files, relative to ${CMAKE_INSTALL_PREFIX}.")
+  set(version_config ${PROJECT_BINARY_DIR}/fmt-config-version.cmake)
+  set(project_config ${PROJECT_BINARY_DIR}/fmt-config.cmake)
+  set(targets_export_name fmt-targets)
+
+  set (INSTALL_TARGETS fmt)
+  if (TARGET fmt-header-only)
+    set(INSTALL_TARGETS ${INSTALL_TARGETS} fmt-header-only)
+  endif ()
+
+  set(FMT_LIB_DIR lib CACHE STRING
+    "Installation directory for libraries, relative to ${CMAKE_INSTALL_PREFIX}.")
+
+  # Generate the version, config and target files into the build directory.
+  write_basic_package_version_file(
+    ${version_config}
+    VERSION ${FMT_VERSION}
+    COMPATIBILITY AnyNewerVersion)
+  configure_package_config_file(
+    ${PROJECT_SOURCE_DIR}/support/cmake/fmt-config.cmake.in
+    ${project_config}
+    INSTALL_DESTINATION ${FMT_CMAKE_DIR})
+  export(TARGETS ${INSTALL_TARGETS} NAMESPACE fmt::
+         FILE ${PROJECT_BINARY_DIR}/${targets_export_name}.cmake)
+
+  # Install version, config and target files.
+  install(
+    FILES ${project_config} ${version_config}
+    DESTINATION ${FMT_CMAKE_DIR})
+  install(EXPORT ${targets_export_name} DESTINATION ${FMT_CMAKE_DIR}
+    NAMESPACE fmt::)
+
+  # Install the library and headers.
+  install(TARGETS ${INSTALL_TARGETS} EXPORT ${targets_export_name}
+          DESTINATION ${FMT_LIB_DIR})
+  install(FILES ${FMT_HEADERS} DESTINATION include/fmt)
+endif ()

--- a/include/ngl/fmt/container.h
+++ b/include/ngl/fmt/container.h
@@ -1,0 +1,82 @@
+/*
+ Formatting library for C++ - standard container utilities
+
+ Copyright (c) 2012 - 2016, Victor Zverovich
+ All rights reserved.
+
+ For the license information refer to format.h.
+ */
+
+#ifndef FMT_CONTAINER_H_
+#define FMT_CONTAINER_H_
+
+#include "format.h"
+
+namespace fmt {
+
+namespace internal {
+
+/**
+  \rst
+  A "buffer" that appends data to a standard container (e.g. typically a
+  ``std::vector`` or ``std::basic_string``).
+  \endrst
+ */
+template <typename Container>
+class ContainerBuffer : public Buffer<typename Container::value_type> {
+ private:
+  Container& container_;
+
+ protected:
+  virtual void grow(std::size_t size) FMT_OVERRIDE {
+    container_.resize(size);
+    this->ptr_ = &container_[0];
+    this->capacity_ = size;
+  }
+
+ public:
+  explicit ContainerBuffer(Container& container) : container_(container) {
+    this->size_ = container_.size();
+    if (this->size_ > 0) {
+      this->ptr_ = &container_[0];
+      this->capacity_ = this->size_;
+    }
+  }
+};
+}  // namespace internal
+
+/**
+  \rst
+  This class template provides operations for formatting and appending data
+  to a standard *container* like ``std::vector`` or ``std::basic_string``.
+
+  **Example**::
+
+    void vecformat(std::vector<char>& dest, fmt::BasicCStringRef<char> format,
+                   fmt::ArgList args) {
+      fmt::BasicContainerWriter<std::vector<char> > appender(dest);
+      appender.write(format, args);
+    }
+    FMT_VARIADIC(void, vecformat, std::vector<char>&,
+                 fmt::BasicCStringRef<char>);
+  \endrst
+ */
+template <class Container>
+class BasicContainerWriter
+  : public BasicWriter<typename Container::value_type> {
+ private:
+  internal::ContainerBuffer<Container> buffer_;
+
+ public:
+  /**
+    \rst
+    Constructs a :class:`fmt::BasicContainerWriter` object.
+    \endrst
+   */
+  explicit BasicContainerWriter(Container& dest)
+  : BasicWriter<typename Container::value_type>(buffer_), buffer_(dest) {}
+};
+
+} // namespace fmt
+
+#endif  // FMT_CONTAINER_H_

--- a/include/ngl/fmt/ostream.cc
+++ b/include/ngl/fmt/ostream.cc
@@ -7,7 +7,7 @@
  For the license information refer to format.h.
  */
 
-#include "fmt/ostream.h"
+#include "ostream.h"
 
 namespace fmt {
 

--- a/include/ngl/fmt/posix.cc
+++ b/include/ngl/fmt/posix.cc
@@ -12,7 +12,7 @@
 # define _CRT_SECURE_NO_WARNINGS
 #endif
 
-#include "fmt/posix.h"
+#include "posix.h"
 
 #include <limits.h>
 #include <sys/types.h>
@@ -21,6 +21,9 @@
 #ifndef _WIN32
 # include <unistd.h>
 #else
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
 # include <windows.h>
 # include <io.h>
 
@@ -72,16 +75,16 @@ fmt::BufferedFile::BufferedFile(
     fmt::CStringRef filename, fmt::CStringRef mode) {
   FMT_RETRY_VAL(file_, FMT_SYSTEM(fopen(filename.c_str(), mode.c_str())), 0);
   if (!file_)
-    throw SystemError(errno, "cannot open file {}", filename);
+    FMT_THROW(SystemError(errno, "cannot open file {}", filename));
 }
 
 void fmt::BufferedFile::close() {
   if (!file_)
     return;
   int result = FMT_SYSTEM(fclose(file_));
-  file_ = 0;
+  file_ = FMT_NULL;
   if (result != 0)
-    throw SystemError(errno, "cannot close file");
+    FMT_THROW(SystemError(errno, "cannot close file"));
 }
 
 // A macro used to prevent expansion of fileno on broken versions of MinGW.
@@ -90,7 +93,7 @@ void fmt::BufferedFile::close() {
 int fmt::BufferedFile::fileno() const {
   int fd = FMT_POSIX_CALL(fileno FMT_ARGS(file_));
   if (fd == -1)
-    throw SystemError(errno, "cannot get file descriptor");
+    FMT_THROW(SystemError(errno, "cannot get file descriptor"));
   return fd;
 }
 
@@ -103,7 +106,7 @@ fmt::File::File(fmt::CStringRef path, int oflag) {
   FMT_RETRY(fd_, FMT_POSIX_CALL(open(path.c_str(), oflag, mode)));
 #endif
   if (fd_ == -1)
-    throw SystemError(errno, "cannot open file {}", path);
+    FMT_THROW(SystemError(errno, "cannot open file {}", path));
 }
 
 fmt::File::~File() FMT_NOEXCEPT {
@@ -121,7 +124,7 @@ void fmt::File::close() {
   int result = FMT_POSIX_CALL(close(fd_));
   fd_ = -1;
   if (result != 0)
-    throw SystemError(errno, "cannot close file");
+    FMT_THROW(SystemError(errno, "cannot close file"));
 }
 
 fmt::LongLong fmt::File::size() const {
@@ -135,7 +138,7 @@ fmt::LongLong fmt::File::size() const {
   if (size_lower == INVALID_FILE_SIZE) {
     DWORD error = GetLastError();
     if (error != NO_ERROR)
-      throw WindowsError(GetLastError(), "cannot get file size");
+      FMT_THROW(WindowsError(GetLastError(), "cannot get file size"));
   }
   fmt::ULongLong long_size = size_upper;
   return (long_size << sizeof(DWORD) * CHAR_BIT) | size_lower;
@@ -143,7 +146,7 @@ fmt::LongLong fmt::File::size() const {
   typedef struct stat Stat;
   Stat file_stat = Stat();
   if (FMT_POSIX_CALL(fstat(fd_, &file_stat)) == -1)
-    throw SystemError(errno, "cannot get file attributes");
+    FMT_THROW(SystemError(errno, "cannot get file attributes"));
   FMT_STATIC_ASSERT(sizeof(fmt::LongLong) >= sizeof(file_stat.st_size),
       "return type of File::size is not large enough");
   return file_stat.st_size;
@@ -154,7 +157,7 @@ std::size_t fmt::File::read(void *buffer, std::size_t count) {
   RWResult result = 0;
   FMT_RETRY(result, FMT_POSIX_CALL(read(fd_, buffer, convert_rwcount(count))));
   if (result < 0)
-    throw SystemError(errno, "cannot read from file");
+    FMT_THROW(SystemError(errno, "cannot read from file"));
   return internal::to_unsigned(result);
 }
 
@@ -162,7 +165,7 @@ std::size_t fmt::File::write(const void *buffer, std::size_t count) {
   RWResult result = 0;
   FMT_RETRY(result, FMT_POSIX_CALL(write(fd_, buffer, convert_rwcount(count))));
   if (result < 0)
-    throw SystemError(errno, "cannot write to file");
+    FMT_THROW(SystemError(errno, "cannot write to file"));
   return internal::to_unsigned(result);
 }
 
@@ -171,7 +174,7 @@ fmt::File fmt::File::dup(int fd) {
   // http://pubs.opengroup.org/onlinepubs/009695399/functions/dup.html
   int new_fd = FMT_POSIX_CALL(dup(fd));
   if (new_fd == -1)
-    throw SystemError(errno, "cannot duplicate file descriptor {}", fd);
+    FMT_THROW(SystemError(errno, "cannot duplicate file descriptor {}", fd));
   return File(new_fd);
 }
 
@@ -179,8 +182,8 @@ void fmt::File::dup2(int fd) {
   int result = 0;
   FMT_RETRY(result, FMT_POSIX_CALL(dup2(fd_, fd)));
   if (result == -1) {
-    throw SystemError(errno,
-      "cannot duplicate file descriptor {} to {}", fd_, fd);
+    FMT_THROW(SystemError(errno,
+      "cannot duplicate file descriptor {} to {}", fd_, fd));
   }
 }
 
@@ -207,7 +210,7 @@ void fmt::File::pipe(File &read_end, File &write_end) {
   int result = FMT_POSIX_CALL(pipe(fds));
 #endif
   if (result != 0)
-    throw SystemError(errno, "cannot create pipe");
+    FMT_THROW(SystemError(errno, "cannot create pipe"));
   // The following assignments don't throw because read_fd and write_fd
   // are closed.
   read_end = File(fds[0]);
@@ -218,7 +221,7 @@ fmt::BufferedFile fmt::File::fdopen(const char *mode) {
   // Don't retry as fdopen doesn't return EINTR.
   FILE *f = FMT_POSIX_CALL(fdopen(fd_, mode));
   if (!f)
-    throw SystemError(errno, "cannot associate stream with file descriptor");
+    FMT_THROW(SystemError(errno, "cannot associate stream with file descriptor"));
   BufferedFile file(f);
   fd_ = -1;
   return file;
@@ -232,7 +235,7 @@ long fmt::getpagesize() {
 #else
   long size = FMT_POSIX_CALL(sysconf(_SC_PAGESIZE));
   if (size < 0)
-    throw SystemError(errno, "cannot get memory page size");
+    FMT_THROW(SystemError(errno, "cannot get memory page size"));
   return size;
 #endif
 }

--- a/include/ngl/fmt/printf.cc
+++ b/include/ngl/fmt/printf.cc
@@ -1,0 +1,32 @@
+/*
+ Formatting library for C++
+
+ Copyright (c) 2012 - 2016, Victor Zverovich
+ All rights reserved.
+
+ For the license information refer to format.h.
+ */
+
+#include "format.h"
+#include "printf.h"
+
+namespace fmt {
+
+template <typename Char>
+void printf(BasicWriter<Char> &w, BasicCStringRef<Char> format, ArgList args);
+
+FMT_FUNC int fprintf(std::FILE *f, CStringRef format, ArgList args) {
+  MemoryWriter w;
+  printf(w, format, args);
+  std::size_t size = w.size();
+  return std::fwrite(w.data(), 1, size, f) < size ? -1 : static_cast<int>(size);
+}
+
+#ifndef FMT_HEADER_ONLY
+
+template void PrintfFormatter<char>::format(CStringRef format);
+template void PrintfFormatter<wchar_t>::format(WCStringRef format);
+
+#endif  // FMT_HEADER_ONLY
+
+}  // namespace fmt

--- a/include/ngl/fmt/string.h
+++ b/include/ngl/fmt/string.h
@@ -10,32 +10,38 @@
 #ifndef FMT_STRING_H_
 #define FMT_STRING_H_
 
-#include "fmt/format.h"
+#include "format.h"
 
 namespace fmt {
 
 namespace internal {
 
-// A buffer that stores data in ``std::string``.
-template <typename Char>
+// A buffer that stores data in ``std::basic_string``.
+template <typename Char, typename Allocator = std::allocator<Char> >
 class StringBuffer : public Buffer<Char> {
+ public:
+  typedef std::basic_string<Char, std::char_traits<Char>, Allocator> StringType;
+
  private:
-  std::basic_string<Char> data_;
+  StringType data_;
 
  protected:
-  virtual void grow(std::size_t size) {
+  virtual void grow(std::size_t size) FMT_OVERRIDE {
     data_.resize(size);
     this->ptr_ = &data_[0];
     this->capacity_ = size;
   }
 
  public:
+  explicit StringBuffer(const Allocator &allocator = Allocator())
+  : data_(allocator) {}
+
   // Moves the data to ``str`` clearing the buffer.
-  void move_to(std::basic_string<Char> &str) {
+  void move_to(StringType &str) {
     data_.resize(this->size_);
     str.swap(data_);
     this->capacity_ = this->size_ = 0;
-    this->ptr_ = 0;
+    this->ptr_ = FMT_NULL;
   }
 };
 }  // namespace internal
@@ -43,8 +49,8 @@ class StringBuffer : public Buffer<Char> {
 /**
   \rst
   This class template provides operations for formatting and writing data
-  into a character stream. The output is stored in ``std::string`` that grows
-  dynamically.
+  into a character stream. The output is stored in a ``std::basic_string``
+  that grows dynamically.
 
   You can use one of the following typedefs for common character types
   and the standard allocator:
@@ -68,13 +74,13 @@ class StringBuffer : public Buffer<Char> {
 
      The answer is 42
 
-  The output can be moved to an ``std::string`` with ``out.move_to()``.
+  The output can be moved to a ``std::basic_string`` with ``out.move_to()``.
   \endrst
  */
-template <typename Char>
+template <typename Char, typename Allocator = std::allocator<Char> >
 class BasicStringWriter : public BasicWriter<Char> {
  private:
-  internal::StringBuffer<Char> buffer_;
+  internal::StringBuffer<Char, Allocator> buffer_;
 
  public:
   /**
@@ -82,14 +88,15 @@ class BasicStringWriter : public BasicWriter<Char> {
     Constructs a :class:`fmt::BasicStringWriter` object.
     \endrst
    */
-  BasicStringWriter() : BasicWriter<Char>(buffer_) {}
+  explicit BasicStringWriter(const Allocator &allocator = Allocator())
+  : BasicWriter<Char>(buffer_), buffer_(allocator) {}
 
   /**
     \rst
     Moves the buffer content to *str* clearing the buffer.
     \endrst
    */
-  void move_to(std::basic_string<Char> &str) {
+  void move_to(std::basic_string<Char, std::char_traits<Char>, Allocator> &str) {
     buffer_.move_to(str);
   }
 };

--- a/include/ngl/fmt/time.h
+++ b/include/ngl/fmt/time.h
@@ -10,8 +10,14 @@
 #ifndef FMT_TIME_H_
 #define FMT_TIME_H_
 
-#include "fmt/format.h"
+#include "format.h"
 #include <ctime>
+
+#ifdef _MSC_VER
+# pragma warning(push)
+# pragma warning(disable: 4702)  // unreachable code
+# pragma warning(disable: 4996)  // "deprecated" functions
+#endif
 
 namespace fmt {
 template <typename ArgFormatter>
@@ -48,6 +54,90 @@ void format_arg(BasicFormatter<char, ArgFormatter> &f,
   }
   format_str = end + 1;
 }
+
+namespace internal{
+inline Null<> localtime_r(...) { return Null<>(); }
+inline Null<> localtime_s(...) { return Null<>(); }
+inline Null<> gmtime_r(...) { return Null<>(); }
+inline Null<> gmtime_s(...) { return Null<>(); }
 }
+
+// Thread-safe replacement for std::localtime
+inline std::tm localtime(std::time_t time) {
+  struct LocalTime {
+    std::time_t time_;
+    std::tm tm_;
+
+    LocalTime(std::time_t t): time_(t) {}
+
+    bool run() {
+      using namespace fmt::internal;
+      return handle(localtime_r(&time_, &tm_));
+    }
+
+    bool handle(std::tm *tm) { return tm != FMT_NULL; }
+
+    bool handle(internal::Null<>) {
+      using namespace fmt::internal;
+      return fallback(localtime_s(&tm_, &time_));
+    }
+
+    bool fallback(int res) { return res == 0; }
+
+    bool fallback(internal::Null<>) {
+      using namespace fmt::internal;
+      std::tm *tm = std::localtime(&time_);
+      if (tm) tm_ = *tm;
+      return tm != FMT_NULL;
+    }
+  };
+  LocalTime lt(time);
+  if (lt.run())
+    return lt.tm_;
+  // Too big time values may be unsupported.
+  FMT_THROW(fmt::FormatError("time_t value out of range"));
+  return std::tm();
+}
+
+// Thread-safe replacement for std::gmtime
+inline std::tm gmtime(std::time_t time) {
+  struct GMTime {
+    std::time_t time_;
+    std::tm tm_;
+
+    GMTime(std::time_t t): time_(t) {}
+
+    bool run() {
+      using namespace fmt::internal;
+      return handle(gmtime_r(&time_, &tm_));
+    }
+
+    bool handle(std::tm *tm) { return tm != FMT_NULL; }
+
+    bool handle(internal::Null<>) {
+      using namespace fmt::internal;
+      return fallback(gmtime_s(&tm_, &time_));
+    }
+
+    bool fallback(int res) { return res == 0; }
+
+    bool fallback(internal::Null<>) {
+      std::tm *tm = std::gmtime(&time_);
+      if (tm != FMT_NULL) tm_ = *tm;
+      return tm != FMT_NULL;
+    }
+  };
+  GMTime gt(time);
+  if (gt.run())
+    return gt.tm_;
+  // Too big time values may be unsupported.
+  FMT_THROW(fmt::FormatError("time_t value out of range"));
+  return std::tm();
+}
+} //namespace fmt
+
+#ifdef _MSC_VER
+# pragma warning(pop)
+#endif
 
 #endif  // FMT_TIME_H_


### PR DESCRIPTION
I encountered the following error when compiling NGL under Fedora 26:

```
In file included from /usr/lib/gcc/x86_64-redhat-linux/7/include/limits.h:194:0,
                 from /usr/lib/gcc/x86_64-redhat-linux/7/include/syslimits.h:7,
                 from /usr/lib/gcc/x86_64-redhat-linux/7/include/limits.h:34,
                 from /usr/include/c++/7/climits:42,
                 from /usr/include/boost/type_traits/is_signed.hpp:16,
                 from /usr/include/boost/type_traits/make_unsigned.hpp:14,
                 from /usr/include/boost/range/size_type.hpp:24,
                 from /usr/include/boost/range/size.hpp:21,
                 from /usr/include/boost/range/functions.hpp:20,
                 from /usr/include/boost/range/iterator_range_core.hpp:38,
                 from /usr/include/boost/range/iterator_range.hpp:13,
                 from /usr/include/boost/range/as_literal.hpp:22,
                 from /usr/include/boost/algorithm/string/trim.hpp:19,
                 from /usr/include/boost/algorithm/string.hpp:19,
                 from src/XMLSerializer.cpp:4:
include/ngl/fmt/format.h: In member function ‘void fmt::internal::ArgFormatterBase<Impl, Char>::visit_char(int)’:
include/ngl/fmt/format.h:1890:20: error: expected unqualified-id before numeric constant
     const unsigned CHAR_WIDTH = 1;
                    ^
make: *** [Makefile:1240: obj/XMLSerializer.o] Error 1
```

The following comment threads suggests that older versions of fmtlib could be incompatible with gcc 7.1+:

https://github.com/fmtlib/fmt/issues/398
https://sourceforge.net/p/daetools/mailman/daetools-users/?viewmonth=201706&viewday=26

This issue can be resolved by replacing the fmt headers with the ones included in the 4.0.0 release of fmt, however i'm unsure of how this affects files that use it (XMLSerializer, Logger, RibExport, ShaderProgram) and whether this compiles on the lab build.